### PR TITLE
fix(logger): make logger a leaf module to break SharedFunctions import cycle

### DIFF
--- a/src/shared/logger/log.ts
+++ b/src/shared/logger/log.ts
@@ -1,5 +1,4 @@
 import * as winston from "winston";
-import { parseEnvVariable } from "../SharedFunctions.js";
 import { enums } from "../enums/enums.js";
 
 export const LOG_SETUP_NAME = "LOG_SETUP";
@@ -18,15 +17,14 @@ const plainFormat = winston.format.printf(({ level, message, timestamp }) => {
 });
 
 const loglevel = ((): LogSetup => {
-	const logSetupOption = parseEnvVariable(LOG_SETUP_NAME);
-	if (logSetupOption.isNone()) {
+	const rawLogSetup = process.env[LOG_SETUP_NAME];
+	if (rawLogSetup === undefined || rawLogSetup.trim().length === 0) {
 		const errorMessage = 'failed to setup logger. "LOG_SETUP" not properly defined.';
 		console.error(errorMessage);
 		console.trace();
 		throw new Error(errorMessage);
 	}
-	const logSetup = logSetupOption.unwrapExpect("log setup name definied");
-	return enums.to(LogSetup, logSetup);
+	return enums.to(LogSetup, rawLogSetup);
 })();
 
 

--- a/test-core/loggerIsLeaf.spec.ts
+++ b/test-core/loggerIsLeaf.spec.ts
@@ -1,0 +1,9 @@
+import { expect } from "chai";
+import { readFileSync } from "node:fs";
+
+describe("logger module", () => {
+	it("does not import from SharedFunctions (must stay a leaf module)", () => {
+		const source = readFileSync("src/shared/logger/log.ts", "utf8");
+		expect(source).to.not.match(/from\s+["']\.\.\/SharedFunctions(\.js)?["']/);
+	});
+});


### PR DESCRIPTION
## Problem

`log.ts` imported `parseEnvVariable` from `SharedFunctions`, which itself imports `log`. When `SharedFunctions` was the first module evaluated, its import of `log` triggered `parseEnvVariable` at the top level — before `SharedFunctions` had finished initialising `optionalDefined`. This left `optionalDefined` in its temporal dead zone and caused:

```
ReferenceError: Cannot access 'optionalDefined' before initialization
    at parseEnvVariable (src/shared/SharedFunctions.ts:19)
    at log.ts (top-level loglevel IIFE)
```

The existing tests never hit this because their import order happens to load `optional.ts` / `log.ts` before `SharedFunctions.ts`. Any new entry point that imports `SharedFunctions` first triggers the crash.

## Fix

Read `process.env[LOG_SETUP_NAME]` directly in the `loglevel` IIFE. Behavior is identical — missing/blank still throws the same error message; valid values still map via `enums.to`. The `SharedFunctions → log` edge is kept; only the reverse edge is removed, making `log` a true leaf module.

## Regression guard

Added `test-core/loggerIsLeaf.spec.ts` — a structural test that reads `log.ts` source and asserts no import from `SharedFunctions` exists. Fails loudly if the dependency is ever re-added, regardless of test-import order.

## Checklist

- `pnpm run lint` ✓
- `pnpm run typecheck` ✓
- `pnpm test` — 18 passing ✓